### PR TITLE
Revert "Implement open.mp and British spelling support; add stock keywords to all functions to prevent compiler warnings."

### DIFF
--- a/src/pawn-easing-functions.inc
+++ b/src/pawn-easing-functions.inc
@@ -11,22 +11,7 @@
 #endif
 #define _pawn_easing_functions_included
 
-
-
-#if !defined _samp_included
-    #tryinclude <open.mp>
-#endif
-
-#if !defined _INC_open_mp
-    #tryinclude <a_samp>
-#endif
-
-#if !defined _samp_included && !defined _INC_open_mp
-    #error Could not find a_samp.inc or open.mp.inc in your include path.
-#endif
-
-
-
+#include <a_samp>
 #include <float>
 #include <YSF>
 
@@ -278,12 +263,12 @@ stock Float:easeInOutBounce(Float:t)
     return (t < 0.5) ? 8.0 * floatpower(2.0, 8.0 * (t - 1.0)) * floatabs(floatsin(t * PI * 7.0)) : 1.0 - 8.0 * floatpower(2.0, -8.0 * t) * floatabs(floatsin(t * PI * 7.0));
 }
 
-stock static Float:lerp(Float:start_value, Float:end_value, Float:pct)
+static Float:lerp(Float:start_value, Float:end_value, Float:pct)
 {
     return (start_value + (end_value - start_value) * pct);
 }
 
-stock static lerp_rgba(color1, color2, Float:t)
+static lerp_rgba(color1, color2, Float:t)
 {
     new r1 = (color1 >> 24) & 0xFF;
     new g1 = (color1 >> 16) & 0xFF;
@@ -303,7 +288,7 @@ stock static lerp_rgba(color1, color2, Float:t)
     return (r << 24) | (g << 16) | (b << 8) | a;
 }
 
-stock static Animator_GetFreeSlot()
+static Animator_GetFreeSlot()
 {
 	for (new i; i < MAX_ANIMATORS; ++i)
 	{
@@ -389,22 +374,10 @@ public Animator_Process()
 					PlayerTextDrawLetterSize(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], x, y);
 					PlayerTextDrawTextSize(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], x, y);
 				}
-                #if !defined _INC_open_mp
-				    case ANIMATOR_COLOR: PlayerTextDrawColor(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], lerp_rgba(g_rgeAnimators[i][e_iColor], g_rgeAnimators[i][e_iTargetColor], ease));
-				#else
-                	case ANIMATOR_COLOR: PlayerTextDrawColour(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], lerp_rgba(g_rgeAnimators[i][e_iColor], g_rgeAnimators[i][e_iTargetColor], ease));
-                #endif
-                #if !defined _INC_open_mp
-                    case ANIMATOR_BOX_COLOR: PlayerTextDrawBoxColor(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], lerp_rgba(g_rgeAnimators[i][e_iColor], g_rgeAnimators[i][e_iTargetColor], ease));
-				#else
-                    case ANIMATOR_BOX_COLOR: PlayerTextDrawBoxColour(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], lerp_rgba(g_rgeAnimators[i][e_iColor], g_rgeAnimators[i][e_iTargetColor], ease));
-                #endif
-                #if !defined _INC_open_mp
-                    case ANIMATOR_BACKGROUND_COLOR: PlayerTextDrawBackgroundColor(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], lerp_rgba(g_rgeAnimators[i][e_iColor], g_rgeAnimators[i][e_iTargetColor], ease));
-                #else
-                   case ANIMATOR_BACKGROUND_COLOR: PlayerTextDrawBackgroundColour(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], lerp_rgba(g_rgeAnimators[i][e_iColor], g_rgeAnimators[i][e_iTargetColor], ease));
-                #endif
-            }
+				case ANIMATOR_COLOR: PlayerTextDrawColor(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], lerp_rgba(g_rgeAnimators[i][e_iColor], g_rgeAnimators[i][e_iTargetColor], ease));
+				case ANIMATOR_BOX_COLOR: PlayerTextDrawBoxColor(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], lerp_rgba(g_rgeAnimators[i][e_iColor], g_rgeAnimators[i][e_iTargetColor], ease));
+				case ANIMATOR_BACKGROUND_COLOR: PlayerTextDrawBackgroundColor(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw], lerp_rgba(g_rgeAnimators[i][e_iColor], g_rgeAnimators[i][e_iTargetColor], ease));
+			}
 
 			PlayerTextDrawShow(g_rgeAnimators[i][e_iPlayerid], g_rgeAnimators[i][e_tdTextdraw]);
 


### PR DESCRIPTION
Reverts alexchwoj/pawn-easing-functions#5. I forgot that YSF does not have support for open.mp, and therefore it won't work.