### PR TITLE
Enhancement: Two Manual Interpolation Functions Added for Precise Size Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ PlayerText_MoveToY(playerid, PlayerText:textdraw, Float:y, duration = 1000, ease
 PlayerText_MoveLetterSize(playerid, PlayerText:textdraw, Float:y, duration = 1000, ease);
 PlayerText_MoveTextSize(playerid, PlayerText:textdraw, Float:x, duration = 1000, ease);
 PlayerText_MoveSize(playerid, PlayerText:textdraw, Float:x, Float:y, duration = 1000, ease);
+PlayerText_InterpolateLetterSize(playerid, PlayerText:textdraw, Float:start_y, Float:end_y, duration = 1000, ease);
+PlayerText_InterpolateTextSize(playerid, PlayerText:textdraw, Float:start_x, Float:end_x, duration = 1000, ease);
 
 // Color
 PlayerText_InterpolateColor(playerid, PlayerText:textdraw, color, duration = 1000, ease);

--- a/examples/progressbar.pwn
+++ b/examples/progressbar.pwn
@@ -1,0 +1,81 @@
+#pragma option -d3
+
+#include <a_samp>
+#include <sscanf2>
+#include <Pawn.CMD>
+#include <pawn-easing-functions>
+
+new g_iAnimator = -1;
+
+new
+    PlayerText:g_ptdLoadBarBG,
+    PlayerText:g_ptdLoadBar
+;
+
+main()
+{
+	print("\npawn-easing-functions\n");
+}
+
+public OnPlayerConnect(playerid)
+{
+    g_ptdLoadBarBG = CreatePlayerTextDraw(playerid, 283.999969, 411.925964, "box");
+    PlayerTextDrawLetterSize(playerid, g_ptdLoadBarBG, 0.0, 1.066666);
+    PlayerTextDrawTextSize(playerid, g_ptdLoadBarBG, 376.000000, 0.0);
+    PlayerTextDrawAlignment(playerid, g_ptdLoadBarBG, 1);
+    PlayerTextDrawColor(playerid, g_ptdLoadBarBG, -1);
+    PlayerTextDrawUseBox(playerid, g_ptdLoadBarBG, 1);
+    PlayerTextDrawBoxColor(playerid, g_ptdLoadBarBG, 404431103);
+    PlayerTextDrawSetShadow(playerid, g_ptdLoadBarBG, 0);
+    PlayerTextDrawBackgroundColor(playerid, g_ptdLoadBarBG, 255);
+    PlayerTextDrawFont(playerid, g_ptdLoadBarBG, 1);
+    PlayerTextDrawSetProportional(playerid, g_ptdLoadBarBG, 1);
+
+    g_ptdLoadBar = CreatePlayerTextDraw(playerid, 284.700012, 412.726013, "box");
+    PlayerTextDrawLetterSize(playerid, g_ptdLoadBar, 0.0, 0.876665);
+    PlayerTextDrawTextSize(playerid, g_ptdLoadBar, 282.13, 0.0);
+    PlayerTextDrawAlignment(playerid, g_ptdLoadBar, 1);
+    PlayerTextDrawColor(playerid, g_ptdLoadBar, -1);
+    PlayerTextDrawUseBox(playerid, g_ptdLoadBar, 1);
+    PlayerTextDrawBoxColor(playerid, g_ptdLoadBar, -239180033);
+    PlayerTextDrawSetShadow(playerid, g_ptdLoadBar, 0);
+    PlayerTextDrawBackgroundColor(playerid, g_ptdLoadBar, 255);
+    PlayerTextDrawFont(playerid, g_ptdLoadBar, 1);
+    PlayerTextDrawSetProportional(playerid, g_ptdLoadBar, 1);
+	return 1;
+}
+
+cmd:progressbar(playerid, const params[])
+{
+    if (g_iAnimator != -1)
+        PlayerText_StopMove(g_iAnimator);
+    
+    PlayerTextDrawShow(playerid, g_ptdLoadBarBG);
+
+    g_iAnimator = PlayerText_InterpolateTextSize(playerid, g_ptdLoadBar, 282.13, 375.38, 1000, EASE_OUT_CUBIC);
+    return 1;
+}
+
+public Animator_OnFinish(playerid, animator, type)
+{
+    if (animator == g_iAnimator && type == ANIMATOR_TEXT_SIZE)
+    {
+        PlayerTextDrawHide(playerid, g_ptdLoadBarBG);
+        PlayerTextDrawHide(playerid, g_ptdLoadBar);
+    }
+    return 1;
+}
+
+
+public OnPlayerRequestClass(playerid, classid)
+{
+    SetSpawnInfo(playerid, 0, 0, 1958.33, 1343.12, 15.36, 269.15, 26, 36, 28, 150, 0, 0);
+    SpawnPlayer(playerid);
+	return 1;
+}
+
+public OnGameModeInit()
+{
+	AddPlayerClass(0, 0.0, 0.0, 1000.0, 0.0, 0, 0, 0, 0, -1, -1);
+	return 1;
+}

--- a/src/pawn-easing-functions.inc
+++ b/src/pawn-easing-functions.inc
@@ -553,6 +553,16 @@ stock PlayerText_MoveSize(playerid, PlayerText:textdraw, Float:x, Float:y, durat
 	return Animator_Insert(playerid, textdraw, start_x, start_y, x, y, duration, ease, ANIMATOR_FULL_SIZE);
 }
 
+stock PlayerText_InterpolateLetterSize(playerid, PlayerText:textdraw, Float:start_y, Float:end_y, duration = 1000, ease)
+{
+	return Animator_Insert(playerid, textdraw, 0.0, start_y, 0.0, end_y, duration, ease, ANIMATOR_LETTER_SIZE);
+}
+
+stock PlayerText_InterpolateTextSize(playerid, PlayerText:textdraw, Float:start_x, Float:end_x, duration = 1000, ease)
+{
+	return Animator_Insert(playerid, textdraw, start_x, 0.0, end_x, 0.0, duration, ease, ANIMATOR_TEXT_SIZE);
+}
+
 stock PlayerText_InterpolateColor(playerid, PlayerText:textdraw, color, duration = 1000, ease)
 {
 	return Animator_Insert(playerid, textdraw, 0.0, 0.0, 0.0, 0.0, duration, ease, ANIMATOR_COLOR, PlayerTextDrawGetColour(playerid, textdraw), color);


### PR DESCRIPTION
This Pull Request introduces two new interpolation functions: `PlayerText_InterpolateLetterSize` and `PlayerText_InterpolateTextSize`. These functions are akin to `PlayerText_MoveLetterSize` and `PlayerText_MoveTextSize`, respectively. However, unlike the aforementioned functions, the new ones do not automatically take the initial interpolation value. Instead, they allow the developer to manually set both the initial and final interpolation values. This eliminates the need to reset the size upon animation completion. These functions are specifically tailored for use in progress bars.

`PlayerText_MoveTextSize`
https://imgur.com/gHhP2ko

`PlayerText_InterpolateLetterSize`
https://imgur.com/W2oEx58